### PR TITLE
Plain console output for Maven and Gradle on Kokoro

### DIFF
--- a/kokoro/continuous.bat
+++ b/kokoro/continuous.bat
@@ -6,6 +6,6 @@ rem there is no minikube installed on this system, so any integration test will 
 rem we porbably also have to install VirtualBox or some other VM driver, it not even clear to me
 rem that kokoro will allow us to run a VM.
 
-cd minikube-gradle-plugin && call gradlew.bat clean build && ^
-cd ../minikube-maven-plugin && call mvnw.bat clean install
+cd minikube-gradle-plugin && call gradlew.bat --console=plain clean build && ^
+cd ../minikube-maven-plugin && call mvnw.bat -B -U clean verify
 exit /b %ERRORLEVEL%

--- a/kokoro/continuous.sh
+++ b/kokoro/continuous.sh
@@ -5,5 +5,5 @@ set -x
 
 cd github/minikube-build-tools-for-java
 
-(cd minikube-gradle-plugin; ./gradlew clean build)
-(cd minikube-maven-plugin; ./mvnw clean install)
+(cd minikube-gradle-plugin; ./gradlew --console=plain clean build)
+(cd minikube-maven-plugin; ./mvnw -B -U clean verify)


### PR DESCRIPTION
Nothing wrong with `install`, but I think `verify` is enough. Can revert it if `install` is desired.